### PR TITLE
Update deployment group names

### DIFF
--- a/appspec.yml
+++ b/appspec.yml
@@ -18,8 +18,8 @@ hooks:
     runas: root
 branch_config:
   main:
-    deploymentGroupName: heroku
+    deploymentGroupName: staging
   deploy:
-    deploymentGroupName: heroku-prod
+    deploymentGroupName: production
     deploymentGroupConfig:
       serviceRoleArn: arn:aws:iam::043472417040:role/codeDeploy


### PR DESCRIPTION
## Overview

See title.

Part of #119.

## Notes

I thought we could keep the `heroku` and `heroku-prod` deployment group names for now but `scripts/` depends on those values to find files in `configs/`. 

The `heroku` and `heroku-prod` deployment groups in AWS have been renamed `staging` and `production`, respectively. The old `staging` and `production` deployment groups are now `staging-legacy` and `production-legacy`.

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs