### PR TITLE
Don't backfill the analytics DAG

### DIFF
--- a/dags/tag_analytics.py
+++ b/dags/tag_analytics.py
@@ -27,9 +27,11 @@ default_args = {
 
 with DAG(
     "tag_analytics",
+    catchup=False,
     default_args=default_args,
     schedule_interval="0 0 1 * *",
-    description="Generates analytics for Metro agenda tags and uploads a CSV file to Google Drive",
+    description="Generates analytics for Metro agenda tags and"
+    "uploads a CSV file to Google Drive",
 ) as dag:
     t1 = TaggedDockerOperator(
         task_id="generate_tag_analytics",


### PR DESCRIPTION
## Overview

This PR stops the analytics DAG from backfilling tasks. This ensures we don't have duplicate file uploads if, for example, we pause the DAG.

Part of Metro-Records/la-metro-councilmatic#1043

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs