### PR TITLE
Use Airflow variable for Google Drive API key in analytics DAG

### DIFF
--- a/dags/tag_analytics.py
+++ b/dags/tag_analytics.py
@@ -1,6 +1,7 @@
 from datetime import timedelta
 
 from airflow import DAG
+from airflow.models import Variable
 
 from constants import (
     LA_METRO_IMAGE_URL,
@@ -22,7 +23,7 @@ default_args = {
         "DATABASE_URL": LA_METRO_DATABASE_URL,
         "SEARCH_URL": LA_METRO_SEARCH_URL,
         "SENTRY_ENVIRONMENT": ENVIRONMENT,
-        "GOOGLE_SERVICE_ACCT_API_KEY": "{{ var.value.google_service_acct_api_key }}"
+        "GOOGLE_SERVICE_ACCT_API_KEY": Variable.get("google_service_acct_api_key")
     },
 }
 

--- a/dags/tag_analytics.py
+++ b/dags/tag_analytics.py
@@ -18,10 +18,11 @@ default_args = {
     "execution_timeout": timedelta(minutes=10),
     "image": LA_METRO_IMAGE_URL,
     "environment": {
+        **LA_METRO_CONFIGS,
         "DATABASE_URL": LA_METRO_DATABASE_URL,
         "SEARCH_URL": LA_METRO_SEARCH_URL,
         "SENTRY_ENVIRONMENT": ENVIRONMENT,
-        **LA_METRO_CONFIGS,
+        "GOOGLE_SERVICE_ACCT_API_KEY": "{{ var.value.google_service_acct_api_key }}"
     },
 }
 


### PR DESCRIPTION
## Overview

This PR transitions to using an Airflow variable (set in the Airflow web GUI) to store the Google Service Account API Key used in the analytics DAG. 

Metro-Records/la-metro-councilmatic#1054 should be merged in first.

### Checklist

Handles #123 

- [x] PR has a descriptive enough title to be useful in changelogs

## Testing Instructions

 * Create an Airflow variable (located in `Admin > Variables` in the toolbar) called `google_service_acct_api_key` (the key is in Bitwarden under `LA Metro Google Service Account Key`)
 * Run the analytics DAG (will fail on upload unless you've set the `REMOTE_ANALYTICS_FOLDER` env var but should authenticate to Google Drive successfully)
