### PR TITLE
Pass analytics folder as Airflow variable

### DIFF
--- a/dags/tag_analytics.py
+++ b/dags/tag_analytics.py
@@ -23,7 +23,8 @@ default_args = {
         "DATABASE_URL": LA_METRO_DATABASE_URL,
         "SEARCH_URL": LA_METRO_SEARCH_URL,
         "SENTRY_ENVIRONMENT": ENVIRONMENT,
-        "GOOGLE_SERVICE_ACCT_API_KEY": Variable.get("google_service_acct_api_key")
+        "GOOGLE_SERVICE_ACCT_API_KEY": Variable.get("google_service_acct_api_key"),
+        "REMOTE_ANALYTICS_FOLDER": Variable.get("remote_analytics_folder")
     },
 }
 


### PR DESCRIPTION
## Overview

This PR passes the remote analytics folder as an Airflow variable to the tag analytics DAG.

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

Connects Metro-Records/la-metro-councilmatic#1043
