### PR TITLE
Make clean_stale_db_objects configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,38 +12,25 @@ An Airflow-based dashboard for the LA Metro ETL pipeline!
 
 Perform the following steps from your terminal.
 
-1. Clone this repository and its submodule, then `cd` into the superproject.
+1. Clone [the LA Metro Councilmatic repository](ttps://github.com/Metro-Records/la-metro-councilmatic) and follow the instructions in its
+README to build and run the application.
 
-    ```bash
-    git clone --recursive https://github.com/Metro-Records/la-metro-dashboard.git
-    cd la-metro-dashboard
-    ```
-2. Build `la-metro-dashboard` application, and create a local `.env` file. Fill
-in the absolute location of your GPG keyring, usually the absolute path for ` ~/.gnupg`.
+2. Clone this repository and create a local `.env` file. 
 
-    ```bash
-    docker-compose build
-    cp .env.example .env
-    # Fill in the correct value for GPG_KEYRING_PATH
-    ```
+```bash
+cp .env.example .env
+```
 
-3. Once the command exits, follow the instructions to build the [LA Metro Councilmatic application](https://github.com/Metro-Records/la-metro-councilmatic#setup)
+Fill in the absolute location of your GPG keyring, usually the absolute path for ` ~/.gnupg`.
 
-4. In order to run the `la-metro-dashboard` application, the `la-metro-councilmatic`
-app must already be running. Open a new shell, move into the `la-metro-councilmatic`
-application, and run it.
 
-	```bash
-    cd la-metro-councilmatic && docker-compose up app
-    ```
+3. Build and run the dashboard:
 
-	Once la-metro-councilmatic is running, in your first shell, run the la-metro-dashboard application.
+```bash
+docker-compose up
+```
 
-	```bash
-	docker-compose up
-	```
-
-5. Finally, to visit the dashboard app, go to http://localhost:8080/admin/. The
+4. Finally, to visit the dashboard app, go to http://localhost:8080/admin/. The
 Councilmatic app runs on http://localhost:8001/.
 
 See the Airflow documentation for more on [navigating the UI](https://airflow.apache.org/docs/stable/ui.html)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -82,3 +82,4 @@ volumes:
 networks:
   app_net:
     name: la-metro-councilmatic_default
+    external: true


### PR DESCRIPTION
## Overview

See title! This PR also updates local development instructions in README.

The primary concept here is params: https://airflow.apache.org/docs/apache-airflow/2.6.3/core-concepts/params.html#params

As of 2.0, Airflow has a new concept called task flows, that are less boilerplate-y and more declarative than traditional DAGs. They also allow you to pass the return value of one task directly to another. Here's more, specifically how to declare dependencies between tasks and traditional operators, which we need to here: https://airflow.apache.org/docs/apache-airflow/2.6.3/tutorial/taskflow.html#adding-dependencies-between-decorated-and-traditional-tasks

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

## Testing Instructions

 * Run the dashboard as described in the README
 * Trigger a `clean_stale_db_objects` job with configuration. Use different values for window and max, or toggle on report, and confirm the DAG behaves as you've configured it.
 
Closes #140, closes #141 
